### PR TITLE
Added ability to share build via link

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 					<div class="dropdown-content">
 						<span class="cDownload" id="download-reset">Reset Script</span>
 						<span class="cDownload" id="download-addperks">AddPerk Script</span>
-						<span class="cDownload" id="download-sharelink" onclick="prompt('Copy this link to share your build:', window.location.href)"><span style="color:orange;">NEW</span> Share Online</span>
+						<span class="cDownload" id="download-sharelink" onclick="prompt('Copy this link to share your build:', window.location.href)"><b style="color:orange;">NEW</b> Share Online</span>
 					</div>
 				</li>
 			</ul>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
 					<div class="dropdown-content">
 						<span class="cDownload" id="download-reset">Reset Script</span>
 						<span class="cDownload" id="download-addperks">AddPerk Script</span>
-						<span class="cDownload" id="download-sharelink" onclick="alert('Copy this link to share your build: \n'+window.location.href)"><span style="color:orange;">NEW</span> Share Online</span>
+						<span class="cDownload" id="download-sharelink" onclick="prompt('Copy this link to share your build:', window.location.href)"><span style="color:orange;">NEW</span> Share Online</span>
 					</div>
 				</li>
 			</ul>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
 					<div class="dropdown-content">
 						<span class="cDownload" id="download-reset">Reset Script</span>
 						<span class="cDownload" id="download-addperks">AddPerk Script</span>
+						<span class="cDownload" id="download-sharelink" onclick="alert('Copy this link to share your build: \n'+window.location.href)"><span style="color:orange;">NEW</span> Share Online</span>
 					</div>
 				</li>
 			</ul>


### PR DESCRIPTION
<!-- Thank you for submitting this PR. You are awesome!
-->

**Checklist**

- [x] My branch is up-to-date with the upstream `master` branch.
- [x] I have added necessary documentation (if appropriate).

**Which issue does this PR fix?**: fixes #16  
Adds a wanted button in the drop-down menu when hovering over the "Save" button:
When "Share Online" is clicked, it will open up a prompt that gives the link to the build so the user can share elsewhere.

**Why do we need this PR?**:
Allows more ways to share builds and share more efficiently online.

**Testing instructions:**
- Create a build
- Go to Save -> Share Online -> copy link
- Paste link in new tab, window, or send to another device to verify the build is identical
- Repeat for different builds
